### PR TITLE
Change PostgreSQL image to multi arch supported image sclorg version

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -31,7 +31,7 @@ components:
 
   - name: postgresql
     container:
-      image: 'quay.io/centos7/postgresql-13-centos7@sha256:994f5c622e2913bda1c4a7fa3b0c7e7f75e7caa3ac66ff1ed70ccfe65c40dd75'
+      image: 'quay.io/sclorg/postgresql-13-c9s'
       env:
         - name: POSTGRESQL_USER
           value: user


### PR DESCRIPTION
Replaces Postgres Image with Multi arch supported image. 

As image: '**quay.io/centos7/postgresql-13-centos7@sha256:994f5c622e2913bda1c4a7fa3b0c7e7f75e7caa3ac66ff1ed70ccfe65c40dd75**' is not multi arch, workspace start failing with CrashLoopBackoff error on IBM Power/Z, so replaced with '**quay.io/sclorg/postgresql-13-c9s**'.
